### PR TITLE
fix(release): label linux binaries as glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: bun-linux-x64
-            artifact: pplx-linux-x64
+            artifact: pplx-linux-glibc-x64
           - os: ubuntu-latest
             target: bun-linux-arm64
-            artifact: pplx-linux-arm64
+            artifact: pplx-linux-glibc-arm64
           - os: macos-latest
             target: bun-darwin-x64
             artifact: pplx-darwin-x64

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ bun run build
 
 This will create a `pplx` executable in the current directory. You can move this to your `PATH` for easy access:
 
+> **Linux release binaries:** The prebuilt Linux assets published on GitHub are Bun `bun-linux-*` builds and are glibc-linked. They are named `pplx-linux-glibc-x64` and `pplx-linux-glibc-arm64` so users on musl-based distributions (for example Alpine) or Android/Bionic environments can identify the libc requirement before downloading. Musl, static, and Android/Bionic binaries are not currently published.
+
 ```bash
 # Move to a directory in your PATH, e.g., /usr/local/bin
 mv pplx /usr/local/bin/

--- a/release.config.js
+++ b/release.config.js
@@ -14,8 +14,8 @@ export default {
       "@semantic-release/github",
       {
         assets: [
-          { path: "dist/pplx-linux-x64", label: "pplx-linux-x64" },
-          { path: "dist/pplx-linux-arm64", label: "pplx-linux-arm64" },
+          { path: "dist/pplx-linux-glibc-x64", label: "pplx-linux-glibc-x64" },
+          { path: "dist/pplx-linux-glibc-arm64", label: "pplx-linux-glibc-arm64" },
           { path: "dist/pplx-darwin-x64", label: "pplx-darwin-x64" },
           { path: "dist/pplx-darwin-arm64", label: "pplx-darwin-arm64" },
           { path: "dist/pplx-windows-x64.exe", label: "pplx-windows-x64.exe" },


### PR DESCRIPTION
### Motivation
- Clarify libc requirements for prebuilt Linux binaries so users on musl-based distributions (Alpine) or Android/Bionic environments can avoid downloading incompatible glibc-linked artifacts.

### Description
- Rename Linux GitHub Actions build artifacts from `pplx-linux-x64` / `pplx-linux-arm64` to `pplx-linux-glibc-x64` / `pplx-linux-glibc-arm64` in `.github/workflows/release.yml`.
- Update `release.config.js` (semantic-release) asset `path` and `label` entries to match the new glibc-specific artifact names.
- Add a README note explaining that published Linux `bun-linux-*` builds are glibc-linked and that musl, static, and Android/Bionic binaries are not currently published.

### Testing
- Ran `bun run build` to compile the `pplx` binary, which completed successfully.
- Executed a Node check that loads `release.config.js` and verifies the presence of `dist/pplx-linux-glibc-x64` and `dist/pplx-linux-glibc-arm64`, which succeeded.
- Ran a Python script to assert the workflow artifacts and release config paths are aligned, which succeeded.
- Ran `git diff --check` to ensure no whitespace or diff errors, which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a198e12170083268d4fff25d7838e37)